### PR TITLE
Add related controller to model projection

### DIFF
--- a/plugin/laravel-projections.json
+++ b/plugin/laravel-projections.json
@@ -111,6 +111,7 @@
     "app/Models/*.php": {
         "type": "model",
         "related": [
+          "app/Http/Controllers/{plural}Controller.php",
           "app/Observers/{}Observer.php",
           "app/Policies/{}Policy.php",
           "database/factories/{}Factory.php",


### PR DESCRIPTION
Allow one to do `:Econtroller` (with no arg) from inside a Model 